### PR TITLE
Disable buffering of the output stream

### DIFF
--- a/shellfn.go
+++ b/shellfn.go
@@ -96,7 +96,7 @@ http_download() {
   headerflag=''
   destflag=''
   if is_command curl; then
-    cmd='curl --fail -sSL'
+    cmd='curl --fail -sSL -N'
     destflag='-o'
     headerflag='-H'
   elif is_command wget; then


### PR DESCRIPTION
Fixes

```
npm i -g up
> up@1.0.1 postinstall /usr/lib/node_modules/up
> curl -sfL https://raw.githubusercontent.com/apex/up/master/install.sh | sh
apex/up: checking GitHub for latest version
apex/up: found version 0.3.8 for linux/amd64
apex/up: downloading https://github.com/apex/up/releases/download/v0.3.8/up_0.3.8_linux_amd64.tar.gz
curl: (23) Failed writing body (0 != 16360)
npm ERR! code ELIFECYCLE
npm ERR! errno 23
npm ERR! up@1.0.1 postinstall: `curl -sfL https://raw.githubusercontent.com/apex/up/master/install.sh | sh`
npm ERR! Exit status 23
npm ERR! 
npm ERR! Failed at the up@1.0.1 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```