### PR TITLE
Add support for private repos using env var or netrc

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,6 +26,49 @@
   revision = "ff0f66940b829dc66c81dad34746d4349b83eb9e"
 
 [[projects]]
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/sdkio",
+    "internal/sdkrand",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/s3",
+    "service/sts"
+  ]
+  revision = "47309c012812d9e9c488a54313e5cdfa7479df93"
+  version = "v1.14.1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/bgentry/go-netrc"
+  packages = ["netrc"]
+  revision = "9fd32a8b3d3d3f9d43c341bfe098430e07609480"
+
+[[projects]]
   branch = "master"
   name = "github.com/blakesmith/ar"
   packages = ["."]
@@ -51,6 +94,12 @@
   packages = ["."]
   revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
   version = "v1.6.0"
+
+[[projects]]
+  name = "github.com/go-ini/ini"
+  packages = ["."]
+  revision = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5"
+  version = "v1.37.0"
 
 [[projects]]
   name = "github.com/golang/protobuf"
@@ -94,6 +143,7 @@
     "internal/filenametemplate",
     "internal/git",
     "internal/linux",
+    "internal/nametemplate",
     "pipeline",
     "pipeline/archive",
     "pipeline/artifactory",
@@ -107,13 +157,14 @@
     "pipeline/nfpm",
     "pipeline/project",
     "pipeline/release",
+    "pipeline/s3",
     "pipeline/scoop",
     "pipeline/sign",
     "pipeline/snapcraft",
     "pipeline/snapshot"
   ]
-  revision = "d8e8af13b55c05b5d472273ebc442a7f24287dd0"
-  version = "v0.66.1"
+  revision = "d2e880cb2cca134f1e835b91e18c1e050b9df412"
+  version = "v0.77.1"
 
 [[projects]]
   name = "github.com/goreleaser/nfpm"
@@ -123,8 +174,19 @@
     "glob",
     "rpm"
   ]
-  revision = "672aa2bd659a22558aa5d727bd6e76ec5d3aafb2"
-  version = "v0.6.3"
+  revision = "a0f04ab682cdfcc312468ac01730e6c64ac65a27"
+  version = "v0.9.1"
+
+[[projects]]
+  name = "github.com/imdario/mergo"
+  packages = ["."]
+  revision = "9d5f1277e9a8ed20c3684bda8fde67c05628518c"
+  version = "v0.3.4"
+
+[[projects]]
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  revision = "0b12d6b5"
 
 [[projects]]
   name = "github.com/masterminds/semver"
@@ -224,6 +286,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c84fbca6dc77176123c873f6bf46213ed6980e9eb92117514cb88af6e7eae232"
+  inputs-digest = "3a8c8e81054679fb353e6b8c61b2d5c72d07d5965c890d9f836208128c2bb702"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/goreleaser/goreleaser"
-  version = ">=0.66.0"
+  version = ">=0.77.1"
 [prune]
   go-tests = true
   unused-packages = true

--- a/shellfn.go
+++ b/shellfn.go
@@ -141,9 +141,9 @@ http_download_curl() {
   source_url=$2
   header=$3
   if [ -z "$header" ]; then
-    code=$(curl -w '%{http_code}' -sL -o "$local_file" "$source_url")
+    code=$(curl -n -w '%{http_code}' -sL -o "$local_file" "$source_url")
   else
-    code=$(curl -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
+    code=$(curl -n -w '%{http_code}' -sL -H "$header" -o "$local_file" "$source_url")
   fi
   if [ "$code" != "200" ]; then
     log_debug "http_download_curl received HTTP status $code"
@@ -184,10 +184,10 @@ github_release() {
   owner_repo=$1
   version=$2
   test -z "$version" && version="latest"
-  giturl="https://github.com/${owner_repo}/releases/${version}"
+  giturl="https://api.github.com/repos/${owner_repo}/releases/${version}"
   json=$(http_copy "$giturl" "Accept:application/json")
   test -z "$json" && return 1
-  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
+  version=$(echo "$json" | tr -s '\n' ' ' | sed 's/.*"tag_name": "//' | sed 's/".*//')
   test -z "$version" && return 1
   echo "$version"
 }


### PR DESCRIPTION
This adds support for using goreleaser against a private github repo. It authenticates using a personal access token. This token must have `repo` permissions to read the private repo. Note: this works for 2FA enabled as well.

It checks for either a `GITHUB_TOKEN` env var or the `api.github.com` machine in your `~/.netrc` file. This supports the token in both the `password` or the `login` field of the github machine.

For example, both of these will work:

```
machine api.github.com
        login codyaray
        password xxxxxxxxxxxxxxxxxxxxxxxxxxx
```

```
machine api.github.com login xxxxxxxxxxxxxxxxxxxxxxxxxxx
```

I also updated the `goreleaser` version so `godownloader` supports `gcflags`, `asmflags`, and similar configuration.

Now you can do something like this:

```
curl -ns https://api.github.com/repos/YOU/YOURAPP/contents/godownloader.sh?ref=master -H Accept:application/vnd.github.raw | bash
```

You're still able to shorten the URL but the header is required. So you might just wrap that in another bash script just to add the header. Create a public gist with the following contents:
```
curl -ns https://api.github.com/repos/YOU/YOURAPP/contents/godownloader.sh?ref=master -H Accept:application/vnd.github.raw | bash -s -- $@
```
Now create a short URL pointing to your public gist. Your users still get a nice short one-liner like
```
curl -ns https://git.io/yourapp | bash
```

Fixes #69 