### PR TITLE
Clean up tmpdir post-installation

### DIFF
--- a/shell_godownloader.go
+++ b/shell_godownloader.go
@@ -89,6 +89,7 @@ execute() {
     install "${srcdir}/${binexe}" "${BINDIR}/"
     log_info "installed ${BINDIR}/${binexe}"
   done
+  rm -rf "${tmpdir}"
 }
 is_supported_platform() {
   platform=$1


### PR DESCRIPTION
Installer script leaves tmpdir behind. With large installations this can mean a lot of disk space (example: gometalinter, 160MB, nontrivial in case of containers). I propose removing tmpdir as the last step.