### PR TITLE
Add -x option to all shell scripts, which enables set -x

### DIFF
--- a/shell_equinoxio.go
+++ b/shell_equinoxio.go
@@ -53,11 +53,12 @@ parse_args() {
   # over-ridden by flag below
 
   BINDIR=${BINDIR:-./bin}
-  while getopts "b:dh?" arg; do
+  while getopts "b:dh?x" arg; do
     case "$arg" in
       b) BINDIR="$OPTARG" ;;
       d) log_set_priority 10 ;;
       h | \?) usage "$0" ;;
+      x) set -x ;;
     esac
   done
   shift $((OPTIND - 1))

--- a/shell_godownloader.go
+++ b/shell_godownloader.go
@@ -55,11 +55,12 @@ parse_args() {
   # over-ridden by flag below
 
   BINDIR=${BINDIR:-./bin}
-  while getopts "b:dh?" arg; do
+  while getopts "b:dh?x" arg; do
     case "$arg" in
       b) BINDIR="$OPTARG" ;;
       d) log_set_priority 10 ;;
       h | \?) usage "$0" ;;
+      x) set -x ;;
     esac
   done
   shift $((OPTIND - 1))

--- a/shell_raw.go
+++ b/shell_raw.go
@@ -65,12 +65,12 @@ parse_args() {
   # over-ridden by flag below
 
   BINDIR=${BINDIR:-./bin}
-  while getopts "b:dh?" arg; do
+  while getopts "b:dh?x" arg; do
     case "$arg" in
       b) BINDIR="$OPTARG" ;;
       d) log_set_priority 10 ;;
-      h) usage "$0" ;;
-      \?) usage "$0" ;;
+      h | \?) usage "$0" ;;
+      x) set -x ;;
     esac
   done
   shift $((OPTIND - 1))


### PR DESCRIPTION
This adds a new `-x` flag to all of the generate shell scripts, which enables `set -x` when the script is run. This is generally useful for debugging these scripts or understanding how they work.