### PR TITLE
Ditch `mktmpdir` for `mktemp -d`

### DIFF
--- a/makeshellfn.sh
+++ b/makeshellfn.sh
@@ -33,7 +33,6 @@ cat \
   uname_os_check.sh \
   uname_arch_check.sh \
   untar.sh \
-  mktmpdir.sh \
   http_download.sh \
   github_release.sh \
   hash_sha256.sh \

--- a/shell_equinoxio.go
+++ b/shell_equinoxio.go
@@ -68,7 +68,7 @@ parse_args() {
 # wrap all destructive operations into a function
 # to prevent curl|bash network truncation and disaster
 execute() {
-  TMPDIR=$(mktmpdir)
+  TMPDIR=$(mktemp -d)
 
   log_info "seeking '${CHANNEL}' latest from $TARGET"
   TARBALL_URL=$(http_copy "$TARGET" | grep "$TARBALL" | cut -d '"' -f 2)

--- a/shell_godownloader.go
+++ b/shell_godownloader.go
@@ -71,7 +71,7 @@ parse_args() {
 # network, either nothing will happen or will syntax error
 # out preventing half-done work
 execute() {
-  tmpdir=$(mktmpdir)
+  tmpdir=$(mktemp -d)
   log_debug "downloading files into ${tmpdir}"
   http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
   http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"

--- a/shell_raw.go
+++ b/shell_raw.go
@@ -100,7 +100,7 @@ adjust_binary() {
 # wrap all destructive operations into a function
 # to prevent curl|bash network truncation and disaster
 execute() {
-  TMPDIR=$(mktmpdir)
+  TMPDIR=$(mktemp -d)
   log_info "downloading from ${TARBALL_URL}"
   http_download "${TMPDIR}/${NAME}" "$TARBALL_URL"
   test ! -d "${BINDIR}" && install -d "${BINDIR}"

--- a/shellfn.go
+++ b/shellfn.go
@@ -1,4 +1,4 @@
-// Code generated 2018-04-10T15:35:32+0000 DO NOT EDIT.
+// Code generated 2019-03-28T16:23:31+0000 DO NOT EDIT.
 package main
 
 const shellfn = `
@@ -130,11 +130,6 @@ untar() {
       return 1
       ;;
   esac
-}
-mktmpdir() {
-  test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
-  mkdir -p "${TMPDIR}"
-  echo "${TMPDIR}"
 }
 http_download_curl() {
   local_file=$1


### PR DESCRIPTION
As of b515fe10e17beeffe25eaf76752bb541a6a30f78 (merged in
351bbf3895e9ca0ef9f3126fc1f3b0425f76ca20, 2019-03-26)), the generated
install script now remembers to clean up its temporary subdirectory
when it exits.

However, the `tmpdir` in `rm -rf "${tmpdir}` is set by a function from
shlib called `mktmpdir`.  `mktmpdir` has wildly different behavior
when `TMPDIR` is set compared to when it's not set:

    mktmpdir() {
      test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
      mkdir -p "${TMPDIR}"
      echo "${TMPDIR}"
    }

* If `TMPDIR` is not already set: it is *necessary* to clean up the
  returned directory when the program is done; it has created a new
  temporary directory that would otherwise be leaked.
* If `TMPDIR` is already set: it is *impermissible* to clean up the
  returned directory when the program is done; it returns the shared
  temporary directory, other programs may be using it, the user may
  not have permission to remove it.

This means that if the environment variable `TMPDIR` is already set
when the install script is run, then the install script will remove
(or attempt to remove) the entire *shared* temporary directory.

The most obvious solution is to just use `mktemp -d` directly.  So do
that.

See https://github.com/goreleaser/godownloader/issues/104