### PR TITLE
fix #108 , generated adjust_format function looks wrong variable

### DIFF
--- a/shell_godownloader.go
+++ b/shell_godownloader.go
@@ -141,9 +141,9 @@ tag_to_version() {
   VERSION=${TAG#v}
 }
 adjust_format() {
-  # change format (tar.gz or zip) based on ARCH
+  # change format (tar.gz or zip) based on OS
   {{- with .Archive.FormatOverrides }}
-  case ${ARCH} in
+  case ${OS} in
   {{- range . }}
     {{ .Goos }}) FORMAT={{ .Format }} ;;
   esac


### PR DESCRIPTION
In adjust_format, decide archive extension by `$ARCH` !
It should by `$OS` .