### PR TITLE
Fix issues with multiple builds

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func makeShell(tplsrc string, cfg *config.Project) ([]byte, error) {
 	// if we want to add a timestamp in the templates this
 	//  function will generate it
 	funcMap := template.FuncMap{
+		"join":             strings.Join,
 		"platformBinaries": makePlatformBinaries,
 		"timestamp": func() string {
 			return time.Now().UTC().Format(time.RFC3339)

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func makeShell(tplsrc string, cfg *config.Project) ([]byte, error) {
 	// if we want to add a timestamp in the templates this
 	//  function will generate it
 	funcMap := template.FuncMap{
+		"platformBinaries": makePlatformBinaries,
 		"timestamp": func() string {
 			return time.Now().UTC().Format(time.RFC3339)
 		},
@@ -46,6 +47,47 @@ func makeShell(tplsrc string, cfg *config.Project) ([]byte, error) {
 	}
 	err = t.Execute(&out, cfg)
 	return out.Bytes(), err
+}
+
+// makePlatform returns a platform string combining goos, goarch, and goarm.
+func makePlatform(goos, goarch, goarm string) string {
+	platform := goos + "/" + goarch
+	if goarch == "arm" && goarm != "" {
+		platform += "v" + goarm
+	}
+	return platform
+}
+
+// makePlatformBinaries returns a map from platforms to a slice of binaries
+// built for that platform.
+func makePlatformBinaries(cfg *config.Project) map[string][]string {
+	platformBinaries := make(map[string][]string)
+	for _, build := range cfg.Builds {
+		ignore := make(map[string]bool)
+		for _, ignoredBuild := range build.Ignore {
+			platform := makePlatform(ignoredBuild.Goos, ignoredBuild.Goarch, ignoredBuild.Goarm)
+			ignore[platform] = true
+		}
+		for _, goos := range build.Goos {
+			for _, goarch := range build.Goarch {
+				switch goarch {
+				case "arm":
+					for _, goarm := range build.Goarm {
+						platform := makePlatform(goos, goarch, goarm)
+						if !ignore[platform] {
+							platformBinaries[platform] = append(platformBinaries[platform], build.Binary)
+						}
+					}
+				default:
+					platform := makePlatform(goos, goarch, "")
+					if !ignore[platform] {
+						platformBinaries[platform] = append(platformBinaries[platform], build.Binary)
+					}
+				}
+			}
+		}
+	}
+	return platformBinaries
 }
 
 // converts the given name template to it's equivalent in shell

--- a/shell_godownloader.go
+++ b/shell_godownloader.go
@@ -169,7 +169,6 @@ adjust_arch() {
 PROJECT_NAME="{{ $.ProjectName }}"
 OWNER={{ $.Release.GitHub.Owner }}
 REPO="{{ $.Release.GitHub.Name }}"
-BINARY={{ (index .Builds 0).Binary }}
 FORMAT={{ .Archive.Format }}
 OS=$(uname_os)
 ARCH=$(uname_arch)

--- a/shell_godownloader.go
+++ b/shell_godownloader.go
@@ -101,26 +101,12 @@ execute() {
 }
 is_supported_platform() {
   platform=$1
-  found=1
   case "$platform" in
-  {{- range $goos := (index $.Builds 0).Goos }}{{ range $goarch := (index $.Builds 0).Goarch }}
-{{ if not (eq $goarch "arm") }}    {{ $goos }}/{{ $goarch }}) found=0 ;;{{ end }}
-  {{- end }}{{ end }}
-  {{- if (index $.Builds 0).Goarm }}
-  {{- range $goos := (index $.Builds 0).Goos }}{{ range $goarch := (index $.Builds 0).Goarch }}{{ range $goarm := (index $.Builds 0).Goarm }}
-{{- if eq $goarch "arm" }}
-    {{ $goos }}/armv{{ $goarm }}) found=0 ;;
+{{- range $platform, $binaries := (platformBinaries .) }}
+    {{ $platform }}) return 0 ;;
 {{- end }}
-  {{- end }}{{ end }}{{ end }}
-  {{- end }}
+    *) return 1 ;;
   esac
-  {{- if (index $.Builds 0).Ignore }}
-  case "$platform" in
-    {{- range $ignore := (index $.Builds 0).Ignore }}
-    {{ $ignore.Goos }}/{{ $ignore.Goarch }}{{ if $ignore.Goarm }}v{{ $ignore.Goarm }}{{ end }}) found=1 ;;{{ end }}
-  esac
-  {{- end }}
-  return $found
 }
 check_platform() {
   if is_supported_platform "$PLATFORM"; then

--- a/shell_godownloader.go
+++ b/shell_godownloader.go
@@ -90,7 +90,7 @@ execute() {
   {{- end }}
   (cd "${tmpdir}" && untar "${TARBALL}")
   test ! -d "${BINDIR}" && install -d "${BINDIR}"
-  for binexe in {{ range .Builds }}"{{ .Binary }}" {{ end }}; do
+  for binexe in $BINARIES; do
     if [ "$OS" = "windows" ]; then
       binexe="${binexe}.exe"
     fi
@@ -99,23 +99,16 @@ execute() {
   done
   rm -rf "${tmpdir}"
 }
-is_supported_platform() {
-  platform=$1
-  case "$platform" in
-{{- range $platform, $binaries := (platformBinaries .) }}
-    {{ $platform }}) return 0 ;;
-{{- end }}
-    *) return 1 ;;
+get_binaries() {
+  case "$PLATFORM" in
+  {{- range $platform, $binaries := (platformBinaries .) }}
+    {{ $platform }}) BINARIES="{{ join $binaries " " }}" ;;
+  {{- end }}
+    *)
+      log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
+      exit 1
+      ;;
   esac
-}
-check_platform() {
-  if is_supported_platform "$PLATFORM"; then
-    # optional logging goes here
-    true
-  else
-    log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
-    exit 1
-  fi
 }
 tag_to_version() {
   if [ -z "${TAG}" ]; then
@@ -186,7 +179,7 @@ uname_arch_check "$ARCH"
 
 parse_args "$@"
 
-check_platform
+get_binaries
 
 tag_to_version
 


### PR DESCRIPTION
This PR fixes issues related to goreleaser configurations with multiple builds:

* Before, only the first build in the config was used, others were ignored, except in `execute`. With this PR, all builds in the config are used.
* Ignored build computations (done with some template logic) were not correct. With this PR, the logic is done in Go, where it is both easier to read and (hopefully) correct.
* Where there were multiple builds with the same binary, the binary was installed multiple times.

These issues were encountered while testing the script generated for `github.com/twpayne/chezmoi`. [chezmoi's `.goreleaser.yml`](https://github.com/twpayne/chezmoi/blob/master/.goreleaser.yaml) includes two builds as a work-around for the lack of cgo support. The specific functions causing problems were:

```sh
is_supported_platform() {
  platform=$1
  found=1
  case "$platform" in
    linux/386) found=0 ;;
    linux/amd64) found=0 ;;
    # ...
    openbsd/armv) found=0 ;;
  esac
  case "$platform" in
    darwin/386) found=1 ;;
    linux/amd64) found=1 ;;
  esac
  return $found
}
```

Note that `linux/amd64` is reported as not supported because it is ignored in the first build and the second build was not used.

```sh
execute() {
  tmpdir=$(mktemp -d)
  log_debug "downloading files into ${tmpdir}"
  http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
  http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
  hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
  srcdir="${tmpdir}"
  (cd "${tmpdir}" && untar "${TARBALL}")
  test ! -d "${BINDIR}" && install -d "${BINDIR}"
  for binexe in "chezmoi" "chezmoi" ; do
    if [ "$OS" = "windows" ]; then
      binexe="${binexe}.exe"
    fi
    install "${srcdir}/${binexe}" "${BINDIR}/"
    log_info "installed ${BINDIR}/${binexe}"
  done
  rm -rf "${tmpdir}"
}
```

Note that in the line beginning `for binexe in`, `"chezmoi"` is repeated twice, as binaries from all builds are used here - and the binaries in the two builds have the same name.

This PR fixes both issues, and removes an unused variable.