### PR TITLE
feat: improve Windows OS detection

### DIFF
--- a/shellfn.go
+++ b/shellfn.go
@@ -62,7 +62,9 @@ log_crit() {
 uname_os() {
   os=$(uname -s | tr '[:upper:]' '[:lower:]')
   case "$os" in
-    msys_nt) os="windows" ;;
+    cygwin_nt*) os="windows" ;;
+    mingw*) os="windows" ;;
+    msys_nt*) os="windows" ;;
   esac
   echo "$os"
 }


### PR DESCRIPTION
As presented by @tralston in https://github.com/twpayne/chezmoi/pull/395.

This improves the detection of Windows from the output of `uname`.

Review appreciated as I don't have access to a Windows system to test, but it looks reasonable given the [documentation of `uname` output on Wikipedia](https://en.wikipedia.org/wiki/Uname).