### PR TITLE
ci: set goproxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ OS=$(shell uname -s)
 
 export PATH := ./bin:$(PATH)
 export GO111MODULE := on
+export GOPROXY := https://gocenter.io
 
 setup: ## Install all the build and lint dependencies
 	mkdir -p bin


### PR DESCRIPTION
Setting GOPROXY to gocenter.io to fix build issue. GoCenter continues…to serve module versions and honor immutability and availablility requirement of a central repo

