### PR TITLE
fix: invalid pseudo version.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,14 @@
 module github.com/goreleaser/godownloader
 
+go 1.12
+
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
+
+// related to an invalid pseudo version in code.gitea.io/gitea v1.10.0-dev.0.20190711052757-a0820e09fbf7
+replace github.com/go-macaron/cors => github.com/go-macaron/cors v0.0.0-20190418220122-6fd6a9bfe14e
+
+// related to an invalid pseudo version in contrib.go.opencensus.io/exporter/ocagent@v0.4.2
+replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.0.3-0.20181214143942-ba49f56771b8
 
 require (
 	github.com/apex/log v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/goreleaser/godownloader
 
 go 1.12
 
-replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
-
 // related to an invalid pseudo version in code.gitea.io/gitea v1.10.0-dev.0.20190711052757-a0820e09fbf7
 replace github.com/go-macaron/cors => github.com/go-macaron/cors v0.0.0-20190418220122-6fd6a9bfe14e
 

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,7 @@ github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e h1:V9a67dfYqPLAvzk5h
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/cenkalti/backoff v2.0.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
-github.com/census-instrumentation/opencensus-proto v0.1.0-0.20181214143942-ba49f56771b8/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/census-instrumentation/opencensus-proto v0.1.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/census-instrumentation/opencensus-proto v0.0.3-0.20181214143942-ba49f56771b8/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20180119173102-7c97cc6fde16/go.mod h1:C0rtzmGXgN78pYR0tGJFhtHgkbAs0lIbHwkB81VxDQE=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/chrismalek/oktasdk-go v0.0.0-20181212195951-3430665dfaa0/go.mod h1:5d8DqS60xkj9k3aXfL3+mXBH0DPYO0FQjcKosxl+b/Q=


### PR DESCRIPTION
Allow to build with go1.13 or with go1.11 and go1.12 with GOPROXY enable.

It's more a "workaround" than a real fix.

The problem need to be fixed by upstream.

Note: #131 need to be reverted.

<details>
<summary>Before the PR  (go1.13)</summary>

```console
$ go version
go version go1.13 linux/amd64

$ go build .
go: github.com/goreleaser/goreleaser@v0.110.0 requires
	gocloud.dev@v0.13.0 requires
	contrib.go.opencensus.io/exporter/ocagent@v0.4.2 requires
	github.com/census-instrumentation/opencensus-proto@v0.1.0-0.20181214143942-ba49f56771b8: invalid pseudo-version: version before v0.1.0 would have negative patch number

$ echo '// related to an invalid pseudo version in code.gitea.io/gitea v1.10.0-dev.0.20190711052757-a0820e09fbf7' >> go.mod
$ echo 'replace github.com/go-macaron/cors => github.com/go-macaron/cors v0.0.0-20190418220122-6fd6a9bfe14e' >> go.mod
$ echo '// related to an invalid pseudo version in contrib.go.opencensus.io/exporter/ocagent@v0.4.2' >> go.mod
$ echo 'replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.0.3-0.20181214143942-ba49f56771b8' >> go.mod

$ go build .
go: github.com/apache/thrift@v0.12.0 used for two different module paths (git.apache.org/thrift.git and github.com/apache/thrift)

$ sed '/git.apache.org/d' go.mod > go.mod.tmp; mv go.mod.tmp go.mod
$ go build .

$ ls -alF | grep godownloader
-rwxr-xr-x 1 ldez ldez 28146427  7 sept. 14:24 godownloader*
```
</details>

<details>
<summary>Before the PR  (go1.12)</summary>

```console
$ go version
go version go1.12.9 linux/amd64

$ export GO111MODULE=on
$ export GOPROXY=https://proxy.golang.org

$ go build .
go: finding github.com/census-instrumentation/opencensus-proto v0.1.0-0.20181214143942-ba49f56771b8
go: github.com/census-instrumentation/opencensus-proto@v0.1.0-0.20181214143942-ba49f56771b8: unexpected status (https://proxy.golang.org/github.com/census-instrumentation/opencensus-proto/@v/v0.1.0-0.20181214143942-ba49f56771b8.info): 410 Gone
go: error loading module requirements

$ echo '// related to an invalid pseudo version in contrib.go.opencensus.io/exporter/ocagent@v0.4.2' >> go.mod
$ echo 'replace github.com/census-instrumentation/opencensus-proto => github.com/census-instrumentation/opencensus-proto v0.0.3-0.20181214143942-ba49f56771b8' >> go.mod

$ go build .

$ ls -alF | grep godownloader
-rwxr-xr-x 1 ldez ldez 29273138  7 sept. 14:45 godownloader*
```
</details>
