### PR TITLE
fix: GOPROXY and dependency issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
 language: go
-go: '1.12.x'
+go: 1.13.x
 
 env:
 - GO111MODULE=on

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ OS=$(shell uname -s)
 
 export PATH := ./bin:$(PATH)
 export GO111MODULE := on
-export GOPROXY := https://gocenter.io
+# enable consistent Go 1.12/1.13 GOPROXY behavior.
+export GOPROXY = https://proxy.golang.org
+
 
 setup: ## Install all the build and lint dependencies
 	mkdir -p bin

--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,6 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+// Fix invalid pseudo-version: revision is longer than canonical (6fd6a9bfe14e)
+replace github.com/go-macaron/cors => github.com/go-macaron/cors v0.0.0-20190418220122-6fd6a9bfe14e

--- a/go.sum
+++ b/go.sum
@@ -125,7 +125,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-macaron/binding v0.0.0-20160711225916-9440f336b443/go.mod h1:u+H6rwW+HQwUL+w5uaEJSpIlVZDye1o9MB4Su0JfRfM=
 github.com/go-macaron/cache v0.0.0-20151013081102-561735312776/go.mod h1:hHAsZm/oBZVcY+S7qdQL6Vbg5VrXF6RuKGuqsszt3Ok=
 github.com/go-macaron/captcha v0.0.0-20190710000913-8dc5911259df/go.mod h1:j9TJ+0nwUOWBvNnm0bheHIPFf3cC62EQo7n7O6PbjZA=
-github.com/go-macaron/cors v0.0.0-20190309005821-6fd6a9bfe14e9/go.mod h1:utmMRnVIrXPSfA9MFcpIYKEpKawjKxf62vv62k4707E=
+github.com/go-macaron/cors v0.0.0-20190418220122-6fd6a9bfe14e/go.mod h1:utmMRnVIrXPSfA9MFcpIYKEpKawjKxf62vv62k4707E=
 github.com/go-macaron/csrf v0.0.0-20180426211211-503617c6b372/go.mod h1:oZGMxI7MBnicI0jJqJvH4qQzyrWKhtiKxLSJKHC+ydc=
 github.com/go-macaron/i18n v0.0.0-20160612092837-ef57533c3b0f/go.mod h1:MePM/dStkAh+PNzAdNSNl4SGDM2EZvZGken+KpJhM7s=
 github.com/go-macaron/inject v0.0.0-20160627170012-d8a0b8677191/go.mod h1:VFI2o2q9kYsC4o7VP1HrEVosiZZTd+MVT3YZx4gqvJw=


### PR DESCRIPTION
Updates Makefile to use official GOPROXY (proxy.golang.org) to detects issues in which third party module proxies differ in checksum behavior for broken/invalid packages. In this case the `proxy.golang.org` less permissive than `gocenter.io`.

The issue can easily be reproduced with the following commands:

Works:
```       
$ go clean -modcache
$ GOPROXY=gocenter.io go get code.gitea.io/gitea@v1.10.0-dev.0.20190711052757-a0820e09fbf7
```

Broken:
```
$ go clean -modcache
$ GOPROXY=proxy.golang.org go get code.gitea.io/gitea@v1.10.0-dev.0.20190711052757-a0820e09fbf7
```