### PR TITLE
Add `--no-same-owner` to prevent uid issues in docker with limited uid's 

### DIFF
--- a/shellfn.go
+++ b/shellfn.go
@@ -124,8 +124,8 @@ uname_arch_check() {
 untar() {
   tarball=$1
   case "${tarball}" in
-    *.tar.gz | *.tgz) tar -xzf "${tarball}" ;;
-    *.tar) tar -xf "${tarball}" ;;
+    *.tar.gz | *.tgz) tar --no-same-owner -xzf "${tarball}" ;;
+    *.tar) tar --no-same-owner -xf "${tarball}" ;;
     *.zip) unzip "${tarball}" ;;
     *)
       log_err "untar unknown archive format for ${tarball}"


### PR DESCRIPTION
When running in docker `userns` may be used to limit the available `uid`'s. I experienced this in Circle CI when attempting to install `golangci-linter` 

Problem detailed by Circle: https://circleci.com/docs/2.0/high-uid-error/#problem

```
root@da91e551efe5:/tmp# curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.19.1
golangci/golangci-lint info checking GitHub for tag 'v1.19.1'
golangci/golangci-lint info found version: 1.19.1 for v1.19.1/linux/amd64
tar: golangci-lint-1.19.1-linux-amd64/LICENSE: Cannot change ownership to uid 1678343834, gid 593637566: Invalid argument
tar: golangci-lint-1.19.1-linux-amd64/README.md: Cannot change ownership to uid 1678343834, gid 593637566: Invalid argument
tar: golangci-lint-1.19.1-linux-amd64/golangci-lint: Cannot change ownership to uid 1678343834, gid 593637566: Invalid argument
tar: Exiting with failure status due to previous errors
```

The result is that an install fails if the `tar` was created by a user with a higher `uid` outside the allowed range. 

The solution I found doc'd was to use the `--no-same-owner` flag in tar so it doesn't attempt to reassign the `uid` of the `user` who created the `tar` file. 

https://github.com/golangci/golangci-lint/issues/752
https://github.com/microsoft/vscode-remote-release/issues/28#issuecomment-496201056
