### PR TITLE
fix: Run golangci-lint only with default linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ cover: test ## Run all the tests and opens the coverage report
 fmt: ## gofmt and goimports all go files
 	find . -name '*.go' -not -wholename './vendor/*' | while read -r file; do gofmt -w -s "$$file"; goimports -w "$$file"; done
 
-lint: ## Run all the linters
-	./bin/golangci-lint run --enable-all --disable wsl ./...
+lint: ## Run default linters
+	./bin/golangci-lint run ./...
 
 precommit: lint  ## Run precommit hook
 


### PR DESCRIPTION
golangci-lint add more and more linters, so new/updated linter can fail
with existing code (e.g. [1]). It's also very slow to run all linters on
pre-commit too, IMO.

We could add golangci-lint config too, but I prefer running default
linters for now, as it's currently failing and reason described above.

[1] https://travis-ci.org/goreleaser/godownloader/builds/632690812?utm_source=github_status&utm_medium=notification
main.go:285:12: mnd: Magic number: 1, in <argument> detected (gomnd)
      os.Exit(1)
                    ^