### PR TITLE
ci: [Proposal] Introduce reviewdog/action-golangci-lint

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,15 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  golangci-lint:
+    name: runner / golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          golangci_lint_flags: "--enable-all --disable wsl ./..."
+          level: warning

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ cover: test ## Run all the tests and opens the coverage report
 fmt: ## gofmt and goimports all go files
 	find . -name '*.go' -not -wholename './vendor/*' | while read -r file; do gofmt -w -s "$$file"; goimports -w "$$file"; done
 
-lint: ## Run all the linters
-	./bin/golangci-lint run --enable-all --disable wsl ./...
+lint: ## Run default linters
+	./bin/golangci-lint run ./...
 
 precommit: lint  ## Run precommit hook
 


### PR DESCRIPTION
This PR can be follow-up of #167. PR #167 will stop using all linters, and
 I propose to introduce
 [reviewdog/action-golangci-lint](https://github.com/reviewdog/action-golangci-lint)
 as one of alternative options to run all linters.

 It runs golangci-lint on Pull Requests and report results in changed lines.
 (Note that for PR from forked repository, it cannot post comments and it
 will use log console to report result though because of permission issue
 [1]).

 It's just an proposal, so please feel to close it if you don't like it or
 ask any questions.

 [1]: https://github.com/reviewdog/reviewdog#option-1-run-reviewdog-from-github-actions-w-secretsgithub_token-experimental